### PR TITLE
[ImageManager.py] Correct VIXImageManager screen syntax

### DIFF
--- a/src/ImageManager.py
+++ b/src/ImageManager.py
@@ -1001,7 +1001,7 @@ class ImageBackup(Screen):
 
 class ImageManagerDownload(Screen):
 	skin = """
-	<screen name="VIXImageManager" position="center,center" size="560,400" title="Image Manager" flags="wfBorder" >
+	<screen name="VIXImageManager" position="center,center" size="560,400" title="Image Manager">
 		<ePixmap pixmap="skin_default/buttons/red.png" position="0,0" size="140,40" alphatest="on" />
 		<ePixmap pixmap="skin_default/buttons/green.png" position="140,0" size="140,40" alphatest="on" />
 		<ePixmap pixmap="skin_default/buttons/yellow.png" position="280,0" size="140,40" alphatest="on" />


### PR DESCRIPTION
The flags="wfBorder" attribute is incorrect, there is no flag "wfBorder".  (There is a "wfNoBorder".)  As borders are the default this attribute is not needed and should be removed.

This change eliminates a logged error when this screen is used.
