### PR TITLE
Add justLoad=True to RecordTimer.loadTimer() calls. This is to disabl…

### DIFF
--- a/src/BackupManager.py
+++ b/src/BackupManager.py
@@ -488,7 +488,10 @@ class VIXBackupManager(Screen):
 			eDVBDB.getInstance().reloadServicelist()
 			eDVBDB.getInstance().reloadBouquets()
 			self.session.nav.PowerTimer.loadTimer()
-			self.session.nav.RecordTimer.loadTimer()
+# Don't check RecordTimers for conflicts. On a restore we may
+# not have the correct tuner configuration (and no USB tuners)...
+#
+			self.session.nav.RecordTimer.loadTimer(justLoad=True)
 			configfile.load()
 		else:
 			print '[BackupManager] Restoring Stage 1 Failed:'

--- a/src/RestoreWizard.py
+++ b/src/RestoreWizard.py
@@ -214,7 +214,10 @@ class RestoreWizard(WizardLanguage, Rc):
 		eDVBDB.getInstance().reloadServicelist()
 		eDVBDB.getInstance().reloadBouquets()
 		self.session.nav.PowerTimer.loadTimer()
-		self.session.nav.RecordTimer.loadTimer()
+# Don't check RecordTimers for conflicts. On a restore we may
+# not have the correct tuner configuration (and no USB tuners)...
+#
+		self.session.nav.RecordTimer.loadTimer(justLoad=True)
 		configfile.load()
 		# self.NextStep = 'plugindetection'
 		self.pleaseWait.close()


### PR DESCRIPTION
…e conflict testing on loading. Needed when loading an initial backup, as the tuner configuration isn't necessarily correct then.