### PR TITLE
ImageManager - menu backup settings overrides any other setting

### DIFF
--- a/src/ImageManager.py
+++ b/src/ImageManager.py
@@ -410,7 +410,7 @@ class VIXImageManager(Screen):
 			else:
 				doBackup = retval == "with backup"
 			if self.sel:
-				if doBackup:
+				if config.imagemanager.autosettingsbackup.value or doBackup:
 					self.doSettingsBackup()
 				else:
 					self.keyRestore3()


### PR DESCRIPTION
If Menu backup setting is set to automatically backup this will override any other setting - as requested by OpenViX