### PR TITLE
ImageManager - add multiboot flashing dis/enable to menu - simplfy sl…

### DIFF
--- a/src/setup.xml
+++ b/src/setup.xml
@@ -24,6 +24,7 @@
         <item level="2" text="Repeat how often" requires="config.imagemanager.schedule" description="Set the repeat interval of backup schedule.">config.imagemanager.repeattype</item>
         <item level="2" text="Query before image backup starts" requires="config.imagemanager.schedule" description="Query before starting image backup.">config.imagemanager.query</item>
         <item level="2" text="Max image backups to keep (0==all)" requires="config.imagemanager.schedule" description="Backups to keep">config.imagemanager.number_to_keep</item>
+        <item level="2" text="Enable Multiboot on multiboot receiver" requires="canMultiBoot" description="Multiboot Yes or No">config.imagemanager.multiboot</item>
     </setup>
     <setup key="vixscriptrunner" title="Script runner settings" titleshort="Settings">
         <item level="2" text="Close window on success" description="Allows you to close the window automatically.">config.scriptrunner.close</item>


### PR DESCRIPTION
…ot list
1. ImageManager Menu - provide multiboot enable/disable for multiboot receivers.
Default: No - disable multi-slot flashing, so that ImageManager flashes only slot 1 - as "normal" receiver"
Enable: Yes, ImageManager will flash any slot.
2. ImageManager: 
- for non multiboot receiver (Or disabled in menu) - will do settings backup (depending on menu settings) and then flash as per normal operation.
- for enabled multiboot receiver, will do settings backup (depending on menu settings), and then just show slots (with empty or image), allowing user to select and then flash.     