### PR TITLE
H9combo - list SDcard

### DIFF
--- a/src/MountManager.py
+++ b/src/MountManager.py
@@ -158,7 +158,10 @@ class VIXDevicesPanel(Screen):
 		print 'DEVICETYPE:',devicetype
 		print 'TEST TYPE MMC:',devicetype.find('mmc')
 		print 'TEST TYPE SDHCI:',devicetype.find('rdb')
-		if devicetype.find('mmc') != -1 and (devicetype.find('rdb') != -1 or (devicetype.find('soc') != -1 and getMachineBuild() != 'h9')):
+		print 'TEST TYPE soc:',devicetype.find('soc')
+		if devicetype.find('mmc') != -1 and (devicetype.find('rdb') != -1 or (devicetype.find('soc') != -1 and  'h9' not in getMachineBuild())):
+			return
+		if  getMachineBuild() == 'h9combo' and "mmcblk0" in device:
 			return
 		d2 = device
 		name = _("HARD DISK: ")
@@ -405,7 +408,9 @@ class VIXDevicePanelConf(Screen, ConfigListScreen):
 		else:
 			device2 = re.sub('[0-9]', '', device)
 		devicetype = path.realpath('/sys/block/' + device2 + '/device')
-		if devicetype.find('mmc') != -1 and (devicetype.find('rdb') != -1 or (devicetype.find('soc') != -1 and getMachineBuild() != 'h9')):
+		if devicetype.find('mmc') != -1 and (devicetype.find('rdb') != -1 or (devicetype.find('soc') != -1 and  'h9' not in getMachineBuild())):
+			return
+		if  getMachineBuild() == 'h9combo' and "mmcblk0" in device:
 			return
 		d2 = device
 		name = _("HARD DISK: ")


### PR DESCRIPTION
Like all zgemma boxes SDcard seems to be recognised differently! H9combo is mmcblk1p1 so needs special treatment for this eMMC receiver.... needs ViX pull on Harddiskmgr as well.