### PR TITLE
Restore wizard - lockout changes to /etc/settings until restore compl…

### DIFF
--- a/src/BackupManager.py
+++ b/src/BackupManager.py
@@ -1325,6 +1325,9 @@ class BackupFiles(Screen):
 		if path.exists('/tmp/3rdPartyPluginsLocation'):
 			tmplist.append('/tmp/3rdPartyPluginsLocation')
 		self.backupdirs = ' '.join(tmplist)
+		config.misc.restorewizardrun.setValue(True)
+		config.misc.restorewizardrun.save()
+		configfile.save()
 		print '[BackupManager] Backup running'
 		backupdate = datetime.now()
 		backupType = "-"

--- a/src/RestoreWizard.py
+++ b/src/RestoreWizard.py
@@ -35,6 +35,7 @@ class RestoreWizard(WizardLanguage, Rc):
 		self.fullbackupfilename = None
 		self.delaymess = None
 		self.selectedDevice = None
+		self.CallNetwork = "dhcp"
 		self.Console = Console()
 
 	def getTranslation(self, text):
@@ -127,10 +128,10 @@ class RestoreWizard(WizardLanguage, Rc):
 
 	def buildList(self, action):
 		if self.NextStep is 'reboot':
-			print "[restorewizard.py] DEBUG 4"
-			import os
-			os.system("reboot")
-			#quitMainloop(2)
+			self.TITLE = "RestoreWiz kill all & reboot"
+			from Screens.Console import Console
+			cmdlist = ["killall -9 enigma2"]
+			exec "self.session.open(Console, title = self.TITLE, cmdlist = cmdlist)"
 		elif self.NextStep is 'settingsquestion' or self.NextStep is 'settingsrestore' or self.NextStep is 'pluginsquestion' or self.NextStep is 'pluginsrestoredevice' or self.NextStep is 'end' or self.NextStep is 'noplugins':
 			self.buildListfinishedCB(False)
 		elif self.NextStep is 'settingrestorestarted':
@@ -151,20 +152,12 @@ class RestoreWizard(WizardLanguage, Rc):
 				self.buildListRef.setTitle(_("Restore wizard"))
 			elif self.feeds == 'DOWN':
 				print '[RestoreWizard] Stage 6: Feeds Down'
-				print "[restorewizard.py] DEBUG 1"
-				config.misc.restorewizardrun.setValue(True)
-				config.misc.restorewizardrun.save()
-				configfile.save()
 				self.didPluginRestore = True
 				self.NextStep = 'reboot'
 				self.buildListRef = self.session.openWithCallback(self.buildListfinishedCB, MessageBox, _("Sorry the feeds are down for maintenance. Please try using Backup manager to restore plugins later."), type=MessageBox.TYPE_INFO, timeout=30, wizard=True)
 				self.buildListRef.setTitle(_("Restore wizard"))
 			elif self.feeds == 'BAD':
 				print '[RestoreWizard] Stage 6: No Network'
-				print "[restorewizard.py] DEBUG 2"
-				config.misc.restorewizardrun.setValue(True)
-				config.misc.restorewizardrun.save()
-				configfile.save()
 				self.didPluginRestore = True
 				self.NextStep = 'reboot'
 				self.buildListRef = self.session.openWithCallback(self.buildListfinishedCB, MessageBox, _("Your %s %s is not connected to the Internet. Please try using Backup manager to restore plugins later.") % (getMachineBrand(), getMachineName()), type=MessageBox.TYPE_INFO, timeout=30, wizard=True)
@@ -209,20 +202,22 @@ class RestoreWizard(WizardLanguage, Rc):
 
 	def doRestoreSettings2(self):
 		print '[RestoreWizard] Stage 2: Restoring settings'
+		self.CallNetwork = [x.split(" ")[3] for x in open("/etc/network/interfaces").read().splitlines() if x.startswith("iface eth0")]
 		self.Console.ePopen("tar -xzvf " + self.fullbackupfilename + " -C /", self.settingRestore_Finished)
 		self.pleaseWait = self.session.open(MessageBox, _("Please wait while settings restore completes..."), type=MessageBox.TYPE_INFO, enable_input=False, wizard=True)
 		self.pleaseWait.setTitle(_("Restore wizard"))
 
 	def settingRestore_Finished(self, result, retval, extra_args=None):
 		self.didSettingsRestore = True
-		eDVBDB.getInstance().reloadServicelist()
-		eDVBDB.getInstance().reloadBouquets()
-		self.session.nav.PowerTimer.loadTimer()
-# Don't check RecordTimers for conflicts. On a restore we may
-# not have the correct tuner configuration (and no USB tuners)...
-#
-		self.session.nav.RecordTimer.loadTimer(justLoad=True)
-		configfile.load()
+		network = [x.split(" ")[3] for x in open("/etc/network/interfaces").read().splitlines() if x.startswith("iface eth0")]
+		if network[0] == "static" and self.CallNetwork[0] == "dhcp":
+			from Plugins.SystemPlugins.NetworkWizard.NetworkWizard import NetworkWizard
+			self.session.openWithCallback(self.AdapterSetupClosed, NetworkWizard)
+		else:
+			self.AdapterSetupClosed()
+
+
+	def AdapterSetupClosed(self, *ret):
 		# self.NextStep = 'plugindetection'
 		self.pleaseWait.close()
 		self.doRestorePlugins1()
@@ -233,10 +228,6 @@ class RestoreWizard(WizardLanguage, Rc):
 	def pluginsRestore_Finished(self, result, retval, extra_args=None):
 		if result:
 			print "[RestoreWizard] opkg install result:\n", result
-		print "[restorewizard.py] DEBUG 3"
-		config.misc.restorewizardrun.setValue(True)
-		config.misc.restorewizardrun.save()
-		configfile.save()
 		self.didPluginRestore = True
 		self.NextStep = 'reboot'
 		self.buildListRef.close(True)


### PR DESCRIPTION
…eted & reboot.
This changes tries to lockout any asychronous code that might update the settings file once restored - something that otherwise happens frequently with the new NimManager code.
As a result of the change the restore for most situations should appear the same and be faster - But for those people that use static IP's the Network wizard is called after a couch or USB image flash so that the network can be restarted - this can be a surprise! but just requires the normal changes in the Network wizard.
I am hoping this will handle most Network situations - if there are issues a reboot should resolve... or I will attempt to fix!
