### PR TITLE
SF8008 & Multibootmgr - incorporate OpenATV commit e713b8a to add GPT format t…

### DIFF
--- a/src/Multibootmgr.py
+++ b/src/Multibootmgr.py
@@ -154,33 +154,56 @@ class MultiBoot(Screen):
 				self.session.open(MessageBox, _("Multiboot manager - Cannot initialize SDcard when running image on SDcard."), MessageBox.TYPE_INFO, timeout=10)
 				self.close
 			else:
-				sda ="sda"
-				size = Harddisk(sda).diskSize()
+				message = _("Multiboot manager - to use this routine %s image must be at OpenViX 4.2.043 or later and USB flashed - reply Yes to continue" %getMachineBuild())
+				ybox = self.session.openWithCallback(self.doFormat, MessageBox, message, MessageBox.TYPE_YESNO, default=True)
+				ybox.setTitle(_("Remove confirmation"))
 
-				if ((float(size) / 1024) / 1024) >= 1:
-					des = _("Size: ") + str(round(((float(size) / 1024) / 1024), 2)) + _("TB")
-				elif (size / 1024) >= 1:
-					des = _("Size: ") + str(round((float(size) / 1024), 2)) + _("GB")
-				if "GB" in des:
-					print "Multibootmgr1", des, "%s" %des[6], size
-					if size/1024 < 6:
-						print "Multibootmgr2", des, "%s" %des[6], size/1024 
-						self.session.open(MessageBox, _("Multiboot manager - The SDcard must be at least 8MB."), MessageBox.TYPE_INFO, timeout=10)
-						self.close
-					else:
-						self.session.open(MessageBox, _("Multiboot manager - SDcard initialization run, please restart OpenViX."), MessageBox.TYPE_INFO, timeout=10)
-						cmdlist = []
-						cmdlist.append("dd if=/dev/zero of=/dev/sda bs=512 count=1 conv=notrunc")
-						cmdlist.append("rm -f /tmp/init.sh")
-						cmdlist.append("echo -e 'sfdisk /dev/sda <<EOF' >> /tmp/init.sh")
-						cmdlist.append("echo -e ',8M' >> /tmp/init.sh")
-						cmdlist.append("echo -e ',2048M' >> /tmp/init.sh")
-						cmdlist.append("echo -e ',8M' >> /tmp/init.sh")
-						cmdlist.append("echo -e ',2048M' >> /tmp/init.sh")
-						cmdlist.append("echo -e 'EOF' >> /tmp/init.sh")
-						cmdlist.append("chmod +x /tmp/init.sh")
-						cmdlist.append("/tmp/init.sh")
-						self.session.open(Console, title = self.TITLE, cmdlist = cmdlist, closeOnSuccess = True)
+	def doFormat(self, answer):
+		if answer is True:
+			sda = "sda"
+			des = " "
+			size = Harddisk(sda).diskSize()
+
+			if ((float(size) / 1024) / 1024) >= 1:
+				des = _("Size: ") + str(round(((float(size) / 1024) / 1024), 2)) + _("TB")
+			elif (size / 1024) >= 1:
+				des = _("Size: ") + str(round((float(size) / 1024), 2)) + _("GB")
+			if "GB" in des:
+				print "Multibootmgr1", des, "%s" %des[6], size
+				if size/1024 < 6:
+					print "Multibootmgr2", des, "%s" %des[6], size/1024 
+					self.session.open(MessageBox, _("Multiboot manager - The SDcard must be at least 8MB."), MessageBox.TYPE_INFO, timeout=10)
+					self.close
+				else:
+					IMAGE_ALIGNMENT=1024
+					KERNEL_PARTITION_SIZE=8192
+					ROOTFS_PARTITION_SIZE=2097152
+					PARTED_START_KERNEL2 = IMAGE_ALIGNMENT
+					PARTED_END_KERNEL2 = int(PARTED_START_KERNEL2) + int(KERNEL_PARTITION_SIZE)
+					PARTED_START_ROOTFS2 = PARTED_END_KERNEL2
+					PARTED_END_ROOTFS2 = int(PARTED_END_KERNEL2) + int(ROOTFS_PARTITION_SIZE)
+					PARTED_START_KERNEL3 = PARTED_END_ROOTFS2
+					PARTED_END_KERNEL3 = int(PARTED_END_ROOTFS2) + int(KERNEL_PARTITION_SIZE)
+					PARTED_START_ROOTFS3 = PARTED_END_KERNEL3
+					PARTED_END_ROOTFS3 = int(PARTED_END_KERNEL3) + int(ROOTFS_PARTITION_SIZE)
+
+					self.session.open(MessageBox, _("Multiboot manager - SDcard initialization run, please restart your Image."), MessageBox.TYPE_INFO, timeout=10)
+					cmdlist = []
+					cmdlist.append("for n in /dev/%s* ; do umount $n > /dev/null 2>&1 ; done"%sda)
+					cmdlist.append("for n in /dev/%s* ; do parted -s /dev/%s rm  ${n:8} > /dev/null 2>&1; done"%(sda,sda))
+					cmdlist.append("dd if=/dev/zero of=/dev/%s bs=512 count=10240 conv=notrunc"%sda)
+					cmdlist.append("partprobe /dev/%s"%sda)
+					cmdlist.append("parted -s /dev/%s mklabel gpt"%sda)
+					cmdlist.append("parted -s /dev/%s unit KiB mkpart kernel2 ext2 %s %s"%(sda,PARTED_START_KERNEL2,PARTED_END_KERNEL2))
+					cmdlist.append("parted -s /dev/%s unit KiB mkpart rootfs2 ext4 %s %s "%(sda,PARTED_START_ROOTFS2,PARTED_END_ROOTFS2))
+					cmdlist.append("parted -s /dev/%s unit KiB mkpart kernel3 ext2 %s %s"%(sda,PARTED_START_KERNEL3,PARTED_END_KERNEL3))
+					cmdlist.append("parted -s /dev/%s unit KiB mkpart rootfs3 ext4 %s %s "%(sda,PARTED_START_ROOTFS3,PARTED_END_ROOTFS3))
+					cmdlist.append("parted -s /dev/%s unit KiB mkpart userdata ext4 %s 100%% "%(sda,PARTED_END_ROOTFS3))  ### Tech note: should be 95% for new mSD cards with discard"
+					cmdlist.append("for n in /dev/%s{1..5} ; do mkfs.ext4 $n ; done"%sda)  ###  we should do kernels in ext2, but ok for small kernel partitions 
+					cmdlist.append("partprobe /dev/%s"%sda)
+					self.session.open(Console, title = self.TITLE, cmdlist = cmdlist, closeOnSuccess = True)
+			else:
+				self.close()
 		else:
 			self.close()
 


### PR DESCRIPTION
…o SD card
Benefit: SF8008 user can use a SD card for both multiboot AND for storage.
The change creates 2 multiboot slots (2 partition pair for kernel and root) and then allocates the rest of the card as a user storage partition 
To use GPT format the SF8008 receiver must be usb flashed to incorporate May 15 drivers - the change asks the user to confirm the usb flash before initialising the card in GPT format.