### PR TITLE
ImageManager - handle large Image zips by extending msg timeout

### DIFF
--- a/src/ImageManager.py
+++ b/src/ImageManager.py
@@ -475,7 +475,7 @@ class VIXImageManager(Screen):
 		if SystemInfo["RecoveryMode"]:
 			self.restore_infobox = self.session.open(MessageBox, _("Please wait while the flash prepares, after the image is flashed, your %s will restart - if error please use Recovery mode to restart." %getMachineMake()), MessageBox.TYPE_INFO, timeout=180, enable_input=False)
 		else:
-			self.restore_infobox = self.session.open(MessageBox, _("Please wait while the flash prepares."), MessageBox.TYPE_INFO, timeout=180, enable_input=False)
+			self.restore_infobox = self.session.open(MessageBox, _("Please wait while the flash prepares."), MessageBox.TYPE_INFO, timeout=240, enable_input=False)
 		self.TEMPDESTROOT = self.BackupDirectory + 'imagerestore'
 		if self.sel.endswith('.zip'):
 			if not path.exists(self.TEMPDESTROOT):


### PR DESCRIPTION
Prevent ImageManager crash - Simple fix to ensure unzip has completed prior to message timer
Issue caused by slow HDD and the very large SF8008 Image zip