### PR TITLE
BackupManager - this reinstates commit d060458 filename prefix

### DIFF
--- a/src/BackupManager.py
+++ b/src/BackupManager.py
@@ -255,7 +255,7 @@ class VIXBackupManager(Screen):
 				del self.emlist[:]
 				mtimes = []
 				for fil in images:
-					if fil.endswith('.tar.gz') and fil.startswith(config.backupmanager.folderprefix.value):
+					if fil.endswith('.tar.gz'): # prefix should only be used for naming files, not browsing them... # and fil.startswith(config.backupmanager.folderprefix.value):
 						mtimes.append((fil, stat(self.BackupDirectory + fil).st_mtime)) # (filname, mtime)
 				for fil in [x[0] for x in sorted(mtimes, key=lambda x: x[1], reverse=True)]: # sort by mtime
 					self.emlist.append(fil)


### PR DESCRIPTION
this allows all backup settings files to be browsed regardless of prefix name