### PR TITLE
Changes to Restore.wiz, MountManager, BackupManager & Plugin.py 

### DIFF
--- a/src/MountManager.py
+++ b/src/MountManager.py
@@ -1,6 +1,6 @@
 # for localized messages
 from boxbranding import getMachineBrand, getMachineName, getMachineBuild
-from os import system, rename, path, mkdir, remove
+from os import system, rename, path, mkdir, remove, statvfs
 from time import sleep
 import re
 
@@ -17,7 +17,6 @@ from Components.config import config, getConfigListEntry, ConfigSelection, NoSav
 from Components.Console import Console
 from Components.Sources.List import List
 from Components.Sources.StaticText import StaticText
-from Components.Harddisk import Harddisk
 from Components.SystemInfo import SystemInfo
 from Tools.LoadPixmap import LoadPixmap
 from Tools.Directories import SCOPE_ACTIVE_SKIN, resolveFilename, pathExists
@@ -213,7 +212,9 @@ class VIXDevicesPanel(Screen):
 			# 		rw = _("None")
 			# 		break
 		f.close()
-		size = Harddisk(device).diskSize()
+		stat = statvfs(d1)
+		cap = int(stat.f_blocks * stat.f_bsize)
+		size = cap / 1000 / 1000
 
 		if ((float(size) / 1024) / 1024) >= 1:
 			des = _("Size: ") + str(round(((float(size) / 1024) / 1024), 2)) + _("TB")
@@ -445,8 +446,9 @@ class VIXDevicePanelConf(Screen, ConfigListScreen):
 				dtype = parts[2]
 				break
 		f.close()
-
-		size = Harddisk(device).diskSize()
+		stat = statvfs(d1)
+		cap = int(stat.f_blocks * stat.f_bsize)
+		size = cap / 1000 / 1000
 		if ((float(size) / 1024) / 1024) >= 1:
 			des = _("Size: ") + str(round(((float(size) / 1024) / 1024), 2)) + _("TB")
 		elif (size / 1024) >= 1:

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -5,7 +5,6 @@ from boxbranding import getBoxType, getImageDistro
 from . import _
 from Plugins.Plugin import PluginDescriptor
 from Components.config import config, ConfigBoolean, configfile
-from Components.Harddisk import harddiskmanager
 from BackupManager import BackupManagerautostart
 from ImageManager import ImageManagerautostart
 from SwapManager import SwapAutostart
@@ -35,16 +34,13 @@ def setLanguageFromBackup(backupfile):
 
 def checkConfigBackup():
 	try:
-		devices = [(r.description, r.mountpoint) for r in harddiskmanager.getMountedPartitions(onlyhotplug=False)]
+		devmounts = []
 		list = []
 		files = []
-		defaultprefix = getImageDistro()[4:]
-		for x in devices:
-			if x[1] == '/':
-				devices.remove(x)
-		if len(devices):
-			for x in devices:
-				devpath = path.join(x[1], 'backup')
+		for dir in ["/media/%s/backup" % media for media in listdir("/media/") if path.isdir(path.join("/media/", media))]:
+			devmounts.append(dir)
+		if len(devmounts):
+			for devpath in devmounts:
 				if path.exists(devpath):
 					try:
 						files = listdir(devpath)


### PR DESCRIPTION
remove calls to Harddisk.py which can be done either directly in local code or by os command.
remove use of walk command which can cause long waits if large disk attached to receiver 

tested on 5 receivers with internal/usb/external devices