### PR TITLE
[BackUpManager] Short key_blue button label name ( cosmetic )

### DIFF
--- a/src/BackupManager.py
+++ b/src/BackupManager.py
@@ -909,7 +909,7 @@ class VIXBackupManagerMenu(Setup):
 		self["key_red"] = Button(_("Cancel"))
 		self["key_green"] = Button(_("OK"))
 		self["key_yellow"] = Button(_("Choose files"))
-		self["key_blue"] = Button(_("Choose local IPK's folder"))
+		self["key_blue"] = Button(_("Choose IPK's folder"))
 
 	def chooseFiles(self):
 		self.session.openWithCallback(self.backupfiles_choosen, BackupSelection)


### PR DESCRIPTION
Short the Label name of "key_blue" in order to fit the whole label on severall skins. The long label name it looks "ugly". ;)

skinName = "VIXBackupManagerMenu" ... Label name --> line 912 of python code [BackUpManager.py]